### PR TITLE
Removed redundant c_str() call to avoid string copying

### DIFF
--- a/tests/test_kel_base.hpp
+++ b/tests/test_kel_base.hpp
@@ -75,7 +75,7 @@ struct test_adder {
 std::string concat(auto... values) {
   std::stringstream result;
   ((result << values), ...);
-  return result.str().c_str();
+  return result.str();
 }
 
 }  // namespace detail

--- a/tests/test_kel_base.hpp
+++ b/tests/test_kel_base.hpp
@@ -75,7 +75,7 @@ struct test_adder {
 std::string concat(auto... values) {
   std::stringstream result;
   ((result << values), ...);
-  return result.str();
+  return std::move(result).str();
 }
 
 }  // namespace detail


### PR DESCRIPTION
Closes #2 